### PR TITLE
Remove prop-types definitions from mjml-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faire/mjml-react",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "MIT",
   "description": "React component library to generate the HTML emails on the fly",
   "keywords": [

--- a/src/extensions/mjml-comment.js
+++ b/src/extensions/mjml-comment.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { handleMjmlProps } from '../utils';
 
 export class MjmlComment extends Component {
-  static propTypes = {
-    children: string.isRequired,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     if (children && children.trim().length) {

--- a/src/extensions/mjml-conditional-comment.js
+++ b/src/extensions/mjml-conditional-comment.js
@@ -1,14 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { MjmlComment } from './mjml-comment';
 
 export class MjmlConditionalComment extends Component {
-  static propTypes = {
-    children: string.isRequired,
-    condition: string.isRequired,
-  };
-
   static defaultProps = {
     condition: 'if gte mso 9',
   };

--- a/src/extensions/mjml-html.js
+++ b/src/extensions/mjml-html.js
@@ -1,12 +1,6 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 export class MjmlHtml extends Component {
-  static propTypes = {
-    tag: string,
-    html: string.isRequired,
-  };
-
   render() {
     const { tag, html } = this.props;
     return React.createElement(tag || 'mj-raw', {

--- a/src/extensions/mjml-tracking-pixel.js
+++ b/src/extensions/mjml-tracking-pixel.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { MjmlRaw } from '../mjml-raw';
 
 export class MjmlTrackingPixel extends Component {
-  static propTypes = {
-    src: string.isRequired,
-  };
-
   render() {
     const { src } = this.props;
     const trackingPixelStyle = {

--- a/src/extensions/mjml-yahoo-style.js
+++ b/src/extensions/mjml-yahoo-style.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { MjmlRaw } from '../mjml-raw';
 
 export class MjmlYahooStyle extends Component {
-  static propTypes = {
-    children: string.isRequired,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     if (children && children.trim().length) {

--- a/src/mjml-accordion-element.js
+++ b/src/mjml-accordion-element.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlAccordionElement extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-accordion-text.js
+++ b/src/mjml-accordion-text.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlAccordionText extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-accordion-title.js
+++ b/src/mjml-accordion-title.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlAccordionTitle extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-accordion.js
+++ b/src/mjml-accordion.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlAccordion extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-accordion', handleMjmlProps(rest), children);

--- a/src/mjml-attributes.js
+++ b/src/mjml-attributes.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlAttributes extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-body.js
+++ b/src/mjml-body.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlBody extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-body', handleMjmlProps(rest), children);

--- a/src/mjml-button.js
+++ b/src/mjml-button.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlButton extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-button', handleMjmlProps(rest), children);

--- a/src/mjml-carousel.js
+++ b/src/mjml-carousel.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlCarousel extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-carousel', handleMjmlProps(rest), children);

--- a/src/mjml-column.js
+++ b/src/mjml-column.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlColumn extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-column', handleMjmlProps(rest), children);

--- a/src/mjml-group.js
+++ b/src/mjml-group.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlGroup extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-group', handleMjmlProps(rest), children);

--- a/src/mjml-head.js
+++ b/src/mjml-head.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlHead extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-head', handleMjmlProps(rest), children);

--- a/src/mjml-hero.js
+++ b/src/mjml-hero.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlHero extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-hero', handleMjmlProps(rest), children);

--- a/src/mjml-html-attribute.js
+++ b/src/mjml-html-attribute.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlHtmlAttribute extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-html-attributes.js
+++ b/src/mjml-html-attributes.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlHtmlAttributes extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-navbar-link.js
+++ b/src/mjml-navbar-link.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlNavbarLink extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-navbar.js
+++ b/src/mjml-navbar.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlNavbar extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-navbar', handleMjmlProps(rest), children);

--- a/src/mjml-preview.js
+++ b/src/mjml-preview.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlPreview extends Component {
-  static propTypes = {
-    children: string,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-preview', handleMjmlProps(rest), children);

--- a/src/mjml-raw.js
+++ b/src/mjml-raw.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlRaw extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-raw', handleMjmlProps(rest), children);

--- a/src/mjml-section.js
+++ b/src/mjml-section.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlSection extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-section', handleMjmlProps(rest), children);

--- a/src/mjml-selector.js
+++ b/src/mjml-selector.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlSelector extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-selector', handleMjmlProps(rest), children);

--- a/src/mjml-social-element.js
+++ b/src/mjml-social-element.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlSocialElement extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement(

--- a/src/mjml-social.js
+++ b/src/mjml-social.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlSocial extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-social', handleMjmlProps(rest), children);

--- a/src/mjml-style.js
+++ b/src/mjml-style.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlStyle extends Component {
-  static propTypes = {
-    children: string,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-style', {

--- a/src/mjml-table.js
+++ b/src/mjml-table.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlTable extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-table', handleMjmlProps(rest), children);

--- a/src/mjml-text.js
+++ b/src/mjml-text.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlText extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-text', handleMjmlProps(rest), children);

--- a/src/mjml-title.js
+++ b/src/mjml-title.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlTitle extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-title', handleMjmlProps(rest), children);

--- a/src/mjml-wrapper.js
+++ b/src/mjml-wrapper.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class MjmlWrapper extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mj-wrapper', handleMjmlProps(rest), children);

--- a/src/mjml.js
+++ b/src/mjml.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
-import { node } from 'prop-types';
 
 import { handleMjmlProps } from './utils';
 
 export class Mjml extends Component {
-  static propTypes = {
-    children: node,
-  };
-
   render() {
     const { children, ...rest } = this.props;
     return React.createElement('mjml', handleMjmlProps(rest), children);


### PR DESCRIPTION
In the wix version of mjml-react it looks like the prop-types are stripped out. Based on the package contents of the wix npm package this happens during the build step.

I think it's safe to remove the prop-types code:
- We won't be using prop-types internally in this package
- The prop-types aren't exported in the dist
- The prop type information in the typescript definition files are already of higher quality

This will also unblock https://github.com/sofn-xyz/mailing/pull/222