### PR TITLE
Move render mjml to html helper functions to utils folder

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,9 +1,5 @@
-import { minify as htmlMinify } from "html-minifier";
 import kebabCase from "lodash.kebabcase";
-import mjml2html from "mjml";
-import { MJMLParsingOptions } from "mjml-core";
 import React from "react";
-import ReactDOMServer from "react-dom/server";
 
 export function mjmlReactComponentFactory<P>(
   mjmlElementName: string
@@ -85,39 +81,4 @@ function convertPropValueToMjml(
 
 function joinClassNames(...classNames: string[]) {
   return classNames.join(" ").trim();
-}
-
-export function render(
-  email: React.ReactElement,
-  options: MJMLParsingOptions = {}
-) {
-  const defaults: MJMLParsingOptions = {
-    keepComments: false,
-    beautify: false,
-    validationLevel: "strict",
-  };
-
-  const html = mjml2html(renderToMjml(email), {
-    ...defaults,
-    ...options,
-    minify: undefined,
-  });
-
-  if (options.minify) {
-    return {
-      html: htmlMinify(html.html, {
-        caseSensitive: true,
-        collapseWhitespace: true,
-        minifyCSS: true,
-        removeComments: true,
-        removeEmptyAttributes: true,
-      }),
-    };
-  }
-
-  return html;
-}
-
-export function renderToMjml(email: React.ReactElement) {
-  return ReactDOMServer.renderToStaticMarkup(email);
 }

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,0 +1,37 @@
+import { minify as htmlMinify } from "html-minifier";
+import mjml2html from "mjml";
+import { MJMLParsingOptions } from "mjml-core";
+import React from "react";
+
+import { renderToMjml } from "./renderToMjml";
+
+export function render(
+  email: React.ReactElement,
+  options: MJMLParsingOptions = {}
+) {
+  const defaults: MJMLParsingOptions = {
+    keepComments: false,
+    beautify: false,
+    validationLevel: "strict",
+  };
+
+  const html = mjml2html(renderToMjml(email), {
+    ...defaults,
+    ...options,
+    minify: undefined,
+  });
+
+  if (options.minify) {
+    return {
+      html: htmlMinify(html.html, {
+        caseSensitive: true,
+        collapseWhitespace: true,
+        minifyCSS: true,
+        removeComments: true,
+        removeEmptyAttributes: true,
+      }),
+    };
+  }
+
+  return html;
+}

--- a/src/utils/renderToMjml.ts
+++ b/src/utils/renderToMjml.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+
+export function renderToMjml(email: React.ReactElement) {
+  return ReactDOMServer.renderToStaticMarkup(email);
+}


### PR DESCRIPTION
These render functions should be exported as standalone functions, so we moved them to the utils folder. There are not related to the utils used for generating the mjml-react components.