### PR TITLE
Remove `react-reconciler` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "module": "dist/esm/index.js",
   "dependencies": {
-    "lodash.kebabcase": "^4.1.1",
-    "react-reconciler": "^0.26.1"
+    "lodash.kebabcase": "^4.1.1"
   }
 }


### PR DESCRIPTION
`react-reconciler` is only used in `render-to-json.js` and `render-to-json2.js`. Since these are both split out of the main
bundle we can require that users of these functions manage the dependency themselves. This will allow everyone else not to include this fragile package in their builds.

fixes: #10