### PR TITLE
Add default value documentation to props

### DIFF
--- a/scripts/generate-mjml-react.ts
+++ b/scripts/generate-mjml-react.ts
@@ -135,6 +135,7 @@ function buildTypesForComponent(mjmlComponent: IMjmlComponent): string {
   const {
     componentName,
     allowedAttributes,
+    defaultAttributes,
     endingTag: isEndingTag,
   } = mjmlComponent;
   const typesFromMjmlAttributes: Record<string, string> = {};
@@ -179,7 +180,16 @@ function buildTypesForComponent(mjmlComponent: IMjmlComponent): string {
   }
 
   const typeStrings = Object.entries(typesFromMjmlAttributes).map(
-    ([attributes, type]) => `${attributes}?: ${type}`
+    ([attributes, type]) => {
+      const definition = `${attributes}?: ${type}`;
+      const defaultValue =
+        defaultAttributes && attributes in defaultAttributes
+          ? defaultAttributes[attributes]
+          : undefined;
+      return defaultValue
+        ? `/** MJML default value: ${defaultValue} */\n${definition}`
+        : definition;
+    }
   );
 
   // allow any property

--- a/src/mjml/MjmlAccordion.tsx
+++ b/src/mjml/MjmlAccordion.tsx
@@ -13,6 +13,7 @@ import {
 
 export interface IMjmlAccordionProps {
   containerBackgroundColor?: string;
+  /** MJML default value: 2px solid black */
   border?: React.CSSProperties["border"];
   fontFamily?: string;
   iconAlign?: "top" | "middle" | "bottom";
@@ -27,6 +28,7 @@ export interface IMjmlAccordionProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlAccordionText.tsx
+++ b/src/mjml/MjmlAccordionText.tsx
@@ -24,6 +24,7 @@ export interface IMjmlAccordionTextProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 16px */
   padding?: Matrix<Pixel | Percentage>;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlAccordionTitle.tsx
+++ b/src/mjml/MjmlAccordionTitle.tsx
@@ -20,6 +20,7 @@ export interface IMjmlAccordionTitleProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 16px */
   padding?: Matrix<Pixel | Percentage>;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlBody.tsx
+++ b/src/mjml/MjmlBody.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { convertPropsToMjmlAttributes, Pixel } from "../utils";
 
 export interface IMjmlBodyProps {
+  /** MJML default value: 600px */
   width?: Pixel;
   backgroundColor?: React.CSSProperties["backgroundColor"];
   className?: string;

--- a/src/mjml/MjmlButton.tsx
+++ b/src/mjml/MjmlButton.tsx
@@ -13,6 +13,7 @@ import {
 } from "../utils";
 
 export interface IMjmlButtonProps {
+  /** MJML default value: center */
   align?: "left" | "center" | "right";
   backgroundColor?: React.CSSProperties["backgroundColor"];
   borderBottom?: string;
@@ -20,7 +21,9 @@ export interface IMjmlButtonProps {
   borderRadius?: React.CSSProperties["borderRadius"];
   borderRight?: string;
   borderTop?: string;
+  /** MJML default value: none */
   border?: React.CSSProperties["border"];
+  /** MJML default value: #ffffff */
   color?: React.CSSProperties["color"];
   containerBackgroundColor?: string;
   fontFamily?: string;
@@ -38,8 +41,10 @@ export interface IMjmlButtonProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   rel?: string;
+  /** MJML default value: _blank */
   target?: string;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];

--- a/src/mjml/MjmlCarousel.tsx
+++ b/src/mjml/MjmlCarousel.tsx
@@ -12,6 +12,7 @@ import {
 } from "../utils";
 
 export interface IMjmlCarouselProps {
+  /** MJML default value: center */
   align?: "left" | "center" | "right";
   borderRadius?: React.CSSProperties["borderRadius"];
   containerBackgroundColor?: string;
@@ -23,6 +24,7 @@ export interface IMjmlCarouselProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   rightIcon?: string;
+  /** MJML default value: visible */
   thumbnails?: "visible" | "hidden";
   tbBorder?: string;
   tbBorderRadius?: Pixel | Percentage;

--- a/src/mjml/MjmlCarouselImage.tsx
+++ b/src/mjml/MjmlCarouselImage.tsx
@@ -15,6 +15,7 @@ export interface IMjmlCarouselImageProps {
   alt?: string;
   href?: string;
   rel?: string;
+  /** MJML default value: _blank */
   target?: string;
   title?: string;
   src?: string;

--- a/src/mjml/MjmlColumn.tsx
+++ b/src/mjml/MjmlColumn.tsx
@@ -19,6 +19,7 @@ export interface IMjmlColumnProps {
   borderRadius?: React.CSSProperties["borderRadius"];
   borderRight?: string;
   borderTop?: string;
+  /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   innerBackgroundColor?: string;
   paddingBottom?: Pixel | Percentage;

--- a/src/mjml/MjmlDivider.tsx
+++ b/src/mjml/MjmlDivider.tsx
@@ -16,12 +16,15 @@ export interface IMjmlDividerProps {
   borderStyle?: React.CSSProperties["borderStyle"];
   borderWidth?: Pixel;
   containerBackgroundColor?: string;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   paddingBottom?: Pixel | Percentage;
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 100% */
   width?: Pixel | Percentage;
+  /** MJML default value: center */
   align?: "left" | "center" | "right";
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlGroup.tsx
+++ b/src/mjml/MjmlGroup.tsx
@@ -8,6 +8,7 @@ import { convertPropsToMjmlAttributes, Pixel, Percentage } from "../utils";
 
 export interface IMjmlGroupProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
+  /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   verticalAlign?: React.CSSProperties["verticalAlign"];
   width?: Pixel | Percentage;

--- a/src/mjml/MjmlHero.tsx
+++ b/src/mjml/MjmlHero.tsx
@@ -12,7 +12,9 @@ import {
 } from "../utils";
 
 export interface IMjmlHeroProps {
+  /** MJML default value: fixed-height */
   mode?: string;
+  /** MJML default value: 0px */
   height?: Pixel | Percentage;
   backgroundUrl?: string;
   backgroundWidth?: Pixel | Percentage;
@@ -26,6 +28,7 @@ export interface IMjmlHeroProps {
   innerPaddingLeft?: Pixel | Percentage;
   innerPaddingRight?: Pixel | Percentage;
   innerPaddingBottom?: Pixel | Percentage;
+  /** MJML default value: 0px */
   padding?: Matrix<Pixel | Percentage>;
   paddingBottom?: Pixel | Percentage;
   paddingLeft?: Pixel | Percentage;

--- a/src/mjml/MjmlImage.tsx
+++ b/src/mjml/MjmlImage.tsx
@@ -20,7 +20,9 @@ export interface IMjmlImageProps {
   sizes?: string;
   title?: string;
   rel?: string;
+  /** MJML default value: center */
   align?: "left" | "center" | "right";
+  /** MJML default value: 0 */
   border?: React.CSSProperties["border"];
   borderBottom?: string;
   borderLeft?: string;
@@ -29,13 +31,16 @@ export interface IMjmlImageProps {
   borderRadius?: React.CSSProperties["borderRadius"];
   containerBackgroundColor?: string;
   fluidOnMobile?: boolean;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   paddingBottom?: Pixel | Percentage;
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: _blank */
   target?: string;
   width?: Pixel;
+  /** MJML default value: auto */
   height?: Pixel;
   maxHeight?: Pixel | Percentage;
   fontSize?: Pixel;

--- a/src/mjml/MjmlNavbar.tsx
+++ b/src/mjml/MjmlNavbar.tsx
@@ -12,6 +12,7 @@ import {
 } from "../utils";
 
 export interface IMjmlNavbarProps {
+  /** MJML default value: center */
   align?: "left" | "center" | "right";
   baseUrl?: string;
   hamburger?: string;

--- a/src/mjml/MjmlNavbarLink.tsx
+++ b/src/mjml/MjmlNavbarLink.tsx
@@ -13,6 +13,7 @@ import {
 } from "../utils";
 
 export interface IMjmlNavbarLinkProps {
+  /** MJML default value: #000000 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
   fontSize?: Pixel;
@@ -20,6 +21,7 @@ export interface IMjmlNavbarLinkProps {
   fontWeight?: string;
   href?: string;
   name?: string;
+  /** MJML default value: _blank */
   target?: string;
   rel?: string;
   letterSpacing?: Pixel | Ephemeral;
@@ -28,6 +30,7 @@ export interface IMjmlNavbarLinkProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 15px 10px */
   padding?: Matrix<Pixel | Percentage>;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];

--- a/src/mjml/MjmlSection.tsx
+++ b/src/mjml/MjmlSection.tsx
@@ -25,8 +25,10 @@ export interface IMjmlSectionProps {
   borderRadius?: React.CSSProperties["borderRadius"];
   borderRight?: string;
   borderTop?: string;
+  /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   fullWidth?: boolean;
+  /** MJML default value: 20px 0 */
   padding?: Matrix<Pixel | Percentage>;
   paddingTop?: Pixel | Percentage;
   paddingBottom?: Pixel | Percentage;

--- a/src/mjml/MjmlSocial.tsx
+++ b/src/mjml/MjmlSocial.tsx
@@ -12,9 +12,11 @@ import {
 } from "../utils";
 
 export interface IMjmlSocialProps {
+  /** MJML default value: center */
   align?: "left" | "right" | "center";
   borderRadius?: React.CSSProperties["borderRadius"];
   containerBackgroundColor?: string;
+  /** MJML default value: #333333 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
   fontSize?: Pixel;
@@ -25,11 +27,13 @@ export interface IMjmlSocialProps {
   iconPadding?: Matrix<Pixel | Percentage>;
   innerPadding?: Matrix<Pixel | Percentage>;
   lineHeight?: Pixel | Percentage;
+  /** MJML default value: horizontal */
   mode?: "horizontal" | "vertical";
   paddingBottom?: Pixel | Percentage;
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   tableLayout?: "auto" | "fixed";
   textPadding?: Matrix<Pixel | Percentage>;

--- a/src/mjml/MjmlSocialElement.tsx
+++ b/src/mjml/MjmlSocialElement.tsx
@@ -12,8 +12,10 @@ import {
 } from "../utils";
 
 export interface IMjmlSocialElementProps {
+  /** MJML default value: left */
   align?: "left" | "center" | "right";
   backgroundColor?: React.CSSProperties["backgroundColor"];
+  /** MJML default value: #000 */
   color?: React.CSSProperties["color"];
   borderRadius?: React.CSSProperties["borderRadius"];
   fontFamily?: string;
@@ -30,6 +32,7 @@ export interface IMjmlSocialElementProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 4px */
   padding?: Matrix<Pixel | Percentage>;
   textPadding?: Matrix<Pixel | Percentage>;
   rel?: string;
@@ -38,6 +41,7 @@ export interface IMjmlSocialElementProps {
   sizes?: string;
   alt?: string;
   title?: string;
+  /** MJML default value: _blank */
   target?: string;
   textDecoration?: React.CSSProperties["textDecoration"];
   verticalAlign?: React.CSSProperties["verticalAlign"];

--- a/src/mjml/MjmlSpacer.tsx
+++ b/src/mjml/MjmlSpacer.tsx
@@ -23,6 +23,7 @@ export interface IMjmlSpacerProps {
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
   padding?: Matrix<Pixel | Percentage>;
+  /** MJML default value: 20px */
   height?: Pixel | Percentage;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlTable.tsx
+++ b/src/mjml/MjmlTable.tsx
@@ -12,11 +12,16 @@ import {
 } from "../utils";
 
 export interface IMjmlTableProps {
+  /** MJML default value: left */
   align?: "left" | "right" | "center";
+  /** MJML default value: none */
   border?: React.CSSProperties["border"];
+  /** MJML default value: 0 */
   cellpadding?: string;
+  /** MJML default value: 0 */
   cellspacing?: string;
   containerBackgroundColor?: string;
+  /** MJML default value: #000000 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
   fontSize?: Pixel;
@@ -26,10 +31,12 @@ export interface IMjmlTableProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   role?: "none" | "presentation";
   tableLayout?: "auto" | "fixed" | "initial" | "inherit";
   verticalAlign?: React.CSSProperties["verticalAlign"];
+  /** MJML default value: 100% */
   width?: Pixel | Percentage;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlText.tsx
+++ b/src/mjml/MjmlText.tsx
@@ -13,8 +13,10 @@ import {
 } from "../utils";
 
 export interface IMjmlTextProps {
+  /** MJML default value: left */
   align?: "left" | "right" | "center" | "justify";
   backgroundColor?: React.CSSProperties["backgroundColor"];
+  /** MJML default value: #000000 */
   color?: React.CSSProperties["color"];
   containerBackgroundColor?: string;
   fontFamily?: string;
@@ -28,6 +30,7 @@ export interface IMjmlTextProps {
   paddingLeft?: Pixel | Percentage;
   paddingRight?: Pixel | Percentage;
   paddingTop?: Pixel | Percentage;
+  /** MJML default value: 10px 25px */
   padding?: Matrix<Pixel | Percentage>;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];

--- a/src/mjml/MjmlWrapper.tsx
+++ b/src/mjml/MjmlWrapper.tsx
@@ -25,8 +25,10 @@ export interface IMjmlWrapperProps {
   borderRadius?: React.CSSProperties["borderRadius"];
   borderRight?: string;
   borderTop?: string;
+  /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   fullWidth?: boolean;
+  /** MJML default value: 20px 0 */
   padding?: Matrix<Pixel | Percentage>;
   paddingTop?: Pixel | Percentage;
   paddingBottom?: Pixel | Percentage;


### PR DESCRIPTION
Related to #9 

We want to see if we can further take advantage of typescript and add information about the props. In this PR we update to provide the MJML default values (i.e. the fallback if the value is undefined)

One caveat here is that this is not a react default/fallback. It is the default from MJML itself. That is why I chose to not use the jsdoc tags, as I feel like they suggest a default value in react, not in MJML itself.

We could alternatively add the value as a default value in React, but this seems superfluous as it forces that value to be set in react when it is a fallback anyway in MJML.

Let me know what you think.