### PR TITLE
CI - add validation that generate-mjml-react.ts has been run 

### DIFF
--- a/.github/workflows/CI_PR_merge_checks.yml
+++ b/.github/workflows/CI_PR_merge_checks.yml
@@ -25,3 +25,22 @@ jobs:
         run: yarn lint
       - name: Test
         run: yarn test
+      - name: Validate generate-mjml-react.ts has been run
+        run: |
+          node --require ts-node/register scripts/generate-mjml-react.ts
+          result=$(git diff --quiet --exit-code HEAD || echo "fail")
+          if [ "$result" == "fail" ]; then
+            echo ">>> MJML REACT CHECK FAILED! <<<"
+            echo "Common cause: upgraded mjml or edited an mj-custom-component -> run"
+            echo ""
+            echo "    $ yarn generate-mjml-react"
+            echo ""
+            git --no-pager diff --stat HEAD
+            echo ""
+            echo "=============="
+            echo ""
+            git --no-pager diff HEAD
+            echo ""
+            echo "=============="
+            exit 1
+          fi

--- a/.github/workflows/CI_PR_merge_checks.yml
+++ b/.github/workflows/CI_PR_merge_checks.yml
@@ -26,21 +26,4 @@ jobs:
       - name: Test
         run: yarn test
       - name: Validate generate-mjml-react.ts has been run
-        run: |
-          yarn generate-mjml-react
-          result=$(git diff --quiet --exit-code HEAD || echo "fail")
-          if [ "$result" == "fail" ]; then
-            echo ">>> MJML REACT CHECK FAILED! <<<"
-            echo "Common cause: upgraded mjml or edited an mj-custom-component -> run"
-            echo ""
-            echo "    $ yarn generate-mjml-react"
-            echo ""
-            git --no-pager diff --stat HEAD
-            echo ""
-            echo "=============="
-            echo ""
-            git --no-pager diff HEAD
-            echo ""
-            echo "=============="
-            exit 1
-          fi
+        run: ./scripts/validateMjmlReactHasBeenRun.sh

--- a/.github/workflows/CI_PR_merge_checks.yml
+++ b/.github/workflows/CI_PR_merge_checks.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn test
       - name: Validate generate-mjml-react.ts has been run
         run: |
-          node --require ts-node/register scripts/generate-mjml-react.ts
+          yarn generate-mjml-react
           result=$(git diff --quiet --exit-code HEAD || echo "fail")
           if [ "$result" == "fail" ]; then
             echo ">>> MJML REACT CHECK FAILED! <<<"

--- a/scripts/generate-mjml-react.ts
+++ b/scripts/generate-mjml-react.ts
@@ -17,6 +17,7 @@ const MJML_REACT_DIR = "src";
 
 const GENERATED_HEADER_TSX = `
 /*
+ * this line should be cause \`Validate generate-mjml-react.ts has been run\` to fail
  * This file is generated. Don't edit it directly.
  * Modify \`scripts/generate-mjml-react.ts\` to make changes to these files
  */

--- a/scripts/generate-mjml-react.ts
+++ b/scripts/generate-mjml-react.ts
@@ -17,7 +17,6 @@ const MJML_REACT_DIR = "src";
 
 const GENERATED_HEADER_TSX = `
 /*
- * this line should be cause \`Validate generate-mjml-react.ts has been run\` to fail
  * This file is generated. Don't edit it directly.
  * Modify \`scripts/generate-mjml-react.ts\` to make changes to these files
  */

--- a/scripts/validateMjmlReactHasBeenRun.sh
+++ b/scripts/validateMjmlReactHasBeenRun.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+yarn generate-mjml-react
+result=$(git diff --quiet --exit-code HEAD || echo "fail")
+if [ "$result" == "fail" ]; then
+    echo ">>> MJML REACT CHECK FAILED! <<<"
+    echo "Common cause: upgraded mjml or edited an mj-custom-component -> run"
+    echo ""
+    echo "    $ yarn generate-mjml-react"
+    echo ""
+    git --no-pager diff --stat HEAD
+    echo ""
+    echo "=============="
+    echo ""
+    git --no-pager diff HEAD
+    echo ""
+    echo "=============="
+    exit 1
+fi


### PR DESCRIPTION
As part of PR integration checks with the repo, ensure that there is no difference before and after running `generate-mjml-react.ts` to verify that authors update the MJML components before pushing if they modified the generation script.

### Verification Blocking PR Example
<img width="940" alt="image" src="https://user-images.githubusercontent.com/112975186/198373235-2cee8f57-7a32-4f22-9693-bced4553c554.png">

---

<img width="613" alt="image" src="https://user-images.githubusercontent.com/112975186/198373432-940fa13d-bc01-4023-a90f-dbcb535524dd.png">

