### PR TITLE
Add command to target build (/dist) folder for Jest tests

### DIFF
--- a/.github/workflows/CI_PR_merge_checks.yml
+++ b/.github/workflows/CI_PR_merge_checks.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Lint
         run: yarn lint
       - name: Test
-        run: yarn test
+        run: yarn test-dist-skip-build
       - name: Validate generate-mjml-react.ts has been run
         run: ./scripts/validateMjmlReactHasBeenRun.sh

--- a/jest-dist.config.js
+++ b/jest-dist.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+
+const baseConfig = require("./jest.config");
+
+module.exports = {
+  ...baseConfig,
+  moduleNameMapper: {
+    "src(.*)$": "<rootDir>/dist/src$1",
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
+
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "jest",
-    "test-dist": "jest --config=jest-dist.config.js",
+    "test-dist-skip-build": "jest --config=jest-dist.config.js",
+    "test-dist": "yarn build && yarn test-dist-skip-build",
     "generate-mjml-react": "ts-node scripts/generate-mjml-react.ts",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "jest",
+    "test-dist": "jest --config=jest-dist.config.js",
     "generate-mjml-react": "ts-node scripts/generate-mjml-react.ts",
     "prepare": "husky install"
   },

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -19,9 +19,10 @@
     "downlevelIteration": true,
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": false,
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "resolveJsonModule": true
   },
 
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Addresses #57 (missing json file from package) and #58 (tests not targeting /dist build folder)

- Added the new `jest-dist.config.js` file that interprets all `"src"` in imports as `"dist/src"` during test execution
- Added 2 custom commands:
  1. `yarn test-dist-skip-build` to run tests using the new config file (to target /dist)
  2. `yarn test-dist` to build then execute `yarn test-dist-skip-build`
- Fixed issue when testing /dist folder, by including `html-entities.json` in both bundles
- CI now uses `yarn test-dist-skip-build`

Note that `yarn test` still targets dev files as usual


### Running `yarn test` to target dev folder
<img width="598" alt="Screen Shot 2022-11-09 at 10 52 49 AM" src="https://user-images.githubusercontent.com/112975186/200914623-39c5d15f-5c04-40eb-86e4-317cdffa66c9.png">

### Running `yarn test-dist` to rebuild + target dist folder (before fix)
<img width="655" alt="Screen Shot 2022-11-09 at 10 53 06 AM" src="https://user-images.githubusercontent.com/112975186/200914654-89c07e76-f7cb-46ad-a324-282403e637aa.png">


### Running `yarn test-dist` to rebuild + target dist folder (after fix)
<img width="561" alt="image" src="https://user-images.githubusercontent.com/112975186/200914688-1cc5f23e-1cf1-4f1e-bba6-317e0f74953d.png">
