### PR TITLE
Update render import in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ And afterwards write a code like a pro:
 
 ```js
 import {
-  render,
   Mjml,
   MjmlHead,
   MjmlTitle,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ import {
   MjmlButton,
   MjmlImage,
 } from "@faire/mjml-react";
+import { render } from "@faire/mjml-react/dist/src/utils/render";
 
 const { html, errors } = render(
   <Mjml>


### PR DESCRIPTION
Addresses #64 - Update how the render function is imported in the README.md

We moved the render method out of the root index file because it requires additional dependencies that package users may not want to install. We encourage users to create their own render method that suits their own needs, but maintain this one as a utility function if users are just looking for a quick implementation. 