### PR TITLE
feat(simplify): prevent mjml-style from breaking css and relax type safety 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ There is an awesome library [mjml](https://mjml.io/) with github repo here [http
 `MJML` is a markup language created by [Mailjet](https://www.mailjet.com/).
 So in order to create emails on the fly we created a library with `React` components.
 
+## Get started today with V2 - 100% backwards compatible with https://github.com/wix-incubator/mjml-react/
+
+V2 is a drop in replacement for https://github.com/wix-incubator/mjml-react/, with some additional support. If there's a component missing you can make a PR against https://github.com/Faire/mjml-react/tree/main-v2 or submit an issue and we'll try to unblock you.
+
 ## What's new in V3?
 
 We wanted V3 of mjml-react to be fairly easy to migrate to from V2. We will implement more advanced features in V4. The main updates in V3 include:
@@ -31,7 +35,7 @@ In V4 we are exploring exciting features that will make mjml-react even more pow
 
 - Improved prop type safety: help ensure correct formatting for props like padding, width, and height
 
-If you want to be on the cutting edge of what is being release, we are publishing a v4-main-alpha version to npm.
+If you want to be on the cutting edge of what is being released, we are publishing a [v4-main-alpha version](https://www.npmjs.com/package/@faire/mjml-react/v/main-alpha) to npm.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ There is an awesome library [mjml](https://mjml.io/) with github repo here [http
 `MJML` is a markup language created by [Mailjet](https://www.mailjet.com/).
 So in order to create emails on the fly we created a library with `React` components.
 
+## What's new in V3?
+
+We wanted V3 of mjml-react to be fairly easy to migrate to from V2. We will implement more advanced features in V4. The main updates in V3 include:
+
+- Typescript: mjml-react is now written in typescript which helps ensure correct props are passed to mjml components
+- Full mjml component support: We use an automated script for pulling mjml components and creating a corresponding mjml-react component. This means we get full support of all components available in the latest mjml version
+- Other small changes: add dangerouslySetInnerHTML in mjml-react for mjml ending tags, update testing, add in-code documenation
+
+## What's coming in V4?
+
+In V4 we are exploring exciting features that will make mjml-react even more powerful. This includes:
+
+- Improved prop type safety: help ensure correct formatting for props like padding, width, and height
+
+If you want to be on the cutting edge of what is being release, we are publishing a v4-main-alpha version to npm.
+
 ## How it works
 
 Install the required dependencies first:

--- a/scripts/generate-mjml-react.ts
+++ b/scripts/generate-mjml-react.ts
@@ -11,8 +11,6 @@ import camelCase from "lodash.camelcase";
 import upperFirst from "lodash.upperfirst";
 import * as path from "path";
 
-import { typeToUnit } from "../src/utils";
-
 const MJML_REACT_DIR = "src";
 
 const UTILS_FILE = "utils";
@@ -129,14 +127,11 @@ function getPropTypeFromMjmlAttributeType(
   if (ATTRIBUTES_TO_USE_CSSProperties_WITH.has(attribute)) {
     return `React.CSSProperties["${attribute}"]`;
   }
-  if (mjmlAttributeType.startsWith("unit")) {
-    const validUnitTypes: string[] = Object.keys(typeToUnit).filter((type) =>
-      mjmlAttributeType.includes(typeToUnit[type as keyof typeof typeToUnit])
-    );
-    if (mjmlAttributeType.endsWith("{1,4}")) {
-      return `Matrix<${validUnitTypes.join(" | ")}>`;
-    }
-    return validUnitTypes.join(" | ");
+  if (
+    mjmlAttributeType.startsWith("unit") &&
+    mjmlAttributeType.includes("px")
+  ) {
+    return "string | number";
   }
   if (mjmlAttributeType === "boolean") {
     return "boolean";
@@ -228,17 +223,13 @@ function buildFileContents({
 }) {
   const { props, createElementProps } =
     buildReactCreateElementProps(componentName);
-  const unitsUsed = ["Matrix", ...Object.keys(typeToUnit)]
-    .filter((unit) => types.includes(unit))
-    .join(", ");
-  const unitsImports = unitsUsed ? ", " + unitsUsed : "";
 
   return `
 ${GENERATED_HEADER_TSX}
 
 import React from "react";
 
-import { convertPropsToMjmlAttributes${unitsImports} } from "../${UTILS_FILE}";
+import { convertPropsToMjmlAttributes } from "../${UTILS_FILE}";
 
 export interface I${reactName}Props {
   ${types}

--- a/scripts/generate-mjml-react.ts
+++ b/scripts/generate-mjml-react.ts
@@ -257,6 +257,13 @@ function buildReactCreateElementProps(componentName: string): {
   const withChildren = "{children, ...props}";
   const withoutChildren = "props";
 
+  if (componentName === "mj-style") {
+    return {
+      props: withChildren,
+      createElementProps:
+        "{ ...convertPropsToMjmlAttributes(props), dangerouslySetInnerHTML: { __html: props.dangerouslySetInnerHTML ? props.dangerouslySetInnerHTML.__html : children } }",
+    };
+  }
   if (HAS_CHILDREN.has(componentName)) {
     return {
       props: withChildren,

--- a/src/mjml/MjmlAccordion.tsx
+++ b/src/mjml/MjmlAccordion.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlAccordionProps {
   containerBackgroundColor?: string;
@@ -17,19 +12,19 @@ export interface IMjmlAccordionProps {
   border?: React.CSSProperties["border"];
   fontFamily?: string;
   iconAlign?: "top" | "middle" | "bottom";
-  iconWidth?: Pixel | Percentage;
-  iconHeight?: Pixel | Percentage;
+  iconWidth?: string | number;
+  iconHeight?: string | number;
   iconWrappedUrl?: string;
   iconWrappedAlt?: string;
   iconUnwrappedUrl?: string;
   iconUnwrappedAlt?: string;
   iconPosition?: "left" | "right";
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlAccordionElement.tsx
+++ b/src/mjml/MjmlAccordionElement.tsx
@@ -4,15 +4,15 @@
  */
 import React from "react";
 
-import { convertPropsToMjmlAttributes, Pixel, Percentage } from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlAccordionElementProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   border?: React.CSSProperties["border"];
   fontFamily?: string;
   iconAlign?: "top" | "middle" | "bottom";
-  iconWidth?: Pixel | Percentage;
-  iconHeight?: Pixel | Percentage;
+  iconWidth?: string | number;
+  iconHeight?: string | number;
   iconWrappedUrl?: string;
   iconWrappedAlt?: string;
   iconUnwrappedUrl?: string;

--- a/src/mjml/MjmlAccordionText.tsx
+++ b/src/mjml/MjmlAccordionText.tsx
@@ -4,28 +4,22 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-  Ephemeral,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlAccordionTextProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontFamily?: string;
   fontWeight?: string;
-  letterSpacing?: Pixel | Ephemeral;
-  lineHeight?: Pixel | Percentage;
+  letterSpacing?: string | number;
+  lineHeight?: string | number;
   color?: React.CSSProperties["color"];
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 16px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlAccordionTitle.tsx
+++ b/src/mjml/MjmlAccordionTitle.tsx
@@ -4,24 +4,19 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlAccordionTitleProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   color?: React.CSSProperties["color"];
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontFamily?: string;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 16px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlBody.tsx
+++ b/src/mjml/MjmlBody.tsx
@@ -4,11 +4,11 @@
  */
 import React from "react";
 
-import { convertPropsToMjmlAttributes, Pixel } from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlBodyProps {
   /** MJML default value: 600px */
-  width?: Pixel;
+  width?: string | number;
   backgroundColor?: React.CSSProperties["backgroundColor"];
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlButton.tsx
+++ b/src/mjml/MjmlButton.tsx
@@ -4,13 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-  Ephemeral,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlButtonProps {
   /** MJML default value: center */
@@ -27,22 +21,22 @@ export interface IMjmlButtonProps {
   color?: React.CSSProperties["color"];
   containerBackgroundColor?: string;
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontStyle?: string;
   fontWeight?: string;
-  height?: Pixel | Percentage;
+  height?: string | number;
   href?: string;
   name?: string;
   title?: string;
-  innerPadding?: Matrix<Pixel | Percentage>;
-  letterSpacing?: Pixel | Ephemeral;
-  lineHeight?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  innerPadding?: string | number;
+  letterSpacing?: string | number;
+  lineHeight?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   rel?: string;
   /** MJML default value: _blank */
   target?: string;
@@ -50,7 +44,7 @@ export interface IMjmlButtonProps {
   textTransform?: React.CSSProperties["textTransform"];
   verticalAlign?: React.CSSProperties["verticalAlign"];
   textAlign?: React.CSSProperties["textAlign"];
-  width?: Pixel | Percentage;
+  width?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlCarousel.tsx
+++ b/src/mjml/MjmlCarousel.tsx
@@ -4,33 +4,28 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlCarouselProps {
   /** MJML default value: center */
   align?: "left" | "center" | "right";
   borderRadius?: React.CSSProperties["borderRadius"];
   containerBackgroundColor?: string;
-  iconWidth?: Pixel | Percentage;
+  iconWidth?: string | number;
   leftIcon?: string;
-  padding?: Matrix<Pixel | Percentage>;
-  paddingTop?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
+  padding?: string | number;
+  paddingTop?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
   rightIcon?: string;
   /** MJML default value: visible */
   thumbnails?: "visible" | "hidden";
   tbBorder?: string;
-  tbBorderRadius?: Pixel | Percentage;
+  tbBorderRadius?: string | number;
   tbHoverBorderColor?: string;
   tbSelectedBorderColor?: string;
-  tbWidth?: Pixel | Percentage;
+  tbWidth?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlCarouselImage.tsx
+++ b/src/mjml/MjmlCarouselImage.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlCarouselImageProps {
   alt?: string;
@@ -22,7 +17,7 @@ export interface IMjmlCarouselImageProps {
   thumbnailsSrc?: string;
   borderRadius?: React.CSSProperties["borderRadius"];
   tbBorder?: string;
-  tbBorderRadius?: Matrix<Pixel | Percentage>;
+  tbBorderRadius?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlColumn.tsx
+++ b/src/mjml/MjmlColumn.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlColumnProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
@@ -22,19 +17,19 @@ export interface IMjmlColumnProps {
   /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   innerBackgroundColor?: string;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   innerBorder?: string;
   innerBorderBottom?: string;
   innerBorderLeft?: string;
-  innerBorderRadius?: Matrix<Pixel | Percentage>;
+  innerBorderRadius?: string | number;
   innerBorderRight?: string;
   innerBorderTop?: string;
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   verticalAlign?: React.CSSProperties["verticalAlign"];
-  width?: Pixel | Percentage;
+  width?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlDivider.tsx
+++ b/src/mjml/MjmlDivider.tsx
@@ -4,26 +4,21 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlDividerProps {
   borderColor?: React.CSSProperties["borderColor"];
   borderStyle?: React.CSSProperties["borderStyle"];
-  borderWidth?: Pixel;
+  borderWidth?: string | number;
   containerBackgroundColor?: string;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  padding?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 100% */
-  width?: Pixel | Percentage;
+  width?: string | number;
   /** MJML default value: center */
   align?: "left" | "center" | "right";
   className?: string;

--- a/src/mjml/MjmlGroup.tsx
+++ b/src/mjml/MjmlGroup.tsx
@@ -4,14 +4,14 @@
  */
 import React from "react";
 
-import { convertPropsToMjmlAttributes, Pixel, Percentage } from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlGroupProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
   verticalAlign?: React.CSSProperties["verticalAlign"];
-  width?: Pixel | Percentage;
+  width?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlHero.tsx
+++ b/src/mjml/MjmlHero.tsx
@@ -4,36 +4,31 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlHeroProps {
   /** MJML default value: fixed-height */
   mode?: string;
   /** MJML default value: 0px */
-  height?: Pixel | Percentage;
+  height?: string | number;
   backgroundUrl?: string;
-  backgroundWidth?: Pixel | Percentage;
-  backgroundHeight?: Pixel | Percentage;
+  backgroundWidth?: string | number;
+  backgroundHeight?: string | number;
   backgroundPosition?: React.CSSProperties["backgroundPosition"];
   borderRadius?: React.CSSProperties["borderRadius"];
   containerBackgroundColor?: string;
   innerBackgroundColor?: string;
-  innerPadding?: Matrix<Pixel | Percentage>;
-  innerPaddingTop?: Pixel | Percentage;
-  innerPaddingLeft?: Pixel | Percentage;
-  innerPaddingRight?: Pixel | Percentage;
-  innerPaddingBottom?: Pixel | Percentage;
+  innerPadding?: string | number;
+  innerPaddingTop?: string | number;
+  innerPaddingLeft?: string | number;
+  innerPaddingRight?: string | number;
+  innerPaddingBottom?: string | number;
   /** MJML default value: 0px */
-  padding?: Matrix<Pixel | Percentage>;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  padding?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   backgroundColor?: React.CSSProperties["backgroundColor"];
   verticalAlign?: React.CSSProperties["verticalAlign"];
   className?: string;

--- a/src/mjml/MjmlImage.tsx
+++ b/src/mjml/MjmlImage.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlImageProps {
   alt?: string;
@@ -32,18 +27,18 @@ export interface IMjmlImageProps {
   containerBackgroundColor?: string;
   fluidOnMobile?: boolean;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  padding?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: _blank */
   target?: string;
-  width?: Pixel;
+  width?: string | number;
   /** MJML default value: auto */
-  height?: Pixel;
-  maxHeight?: Pixel | Percentage;
-  fontSize?: Pixel;
+  height?: string | number;
+  maxHeight?: string | number;
+  fontSize?: string | number;
   usemap?: string;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlNavbar.tsx
+++ b/src/mjml/MjmlNavbar.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlNavbarProps {
   /** MJML default value: center */
@@ -20,21 +15,21 @@ export interface IMjmlNavbarProps {
   icoOpen?: string;
   icoClose?: string;
   icoColor?: string;
-  icoFontSize?: Pixel | Percentage;
+  icoFontSize?: string | number;
   icoFontFamily?: string;
   icoTextTransform?: string;
-  icoPadding?: Matrix<Pixel | Percentage>;
-  icoPaddingLeft?: Pixel | Percentage;
-  icoPaddingTop?: Pixel | Percentage;
-  icoPaddingRight?: Pixel | Percentage;
-  icoPaddingBottom?: Pixel | Percentage;
-  padding?: Matrix<Pixel | Percentage>;
-  paddingLeft?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
+  icoPadding?: string | number;
+  icoPaddingLeft?: string | number;
+  icoPaddingTop?: string | number;
+  icoPaddingRight?: string | number;
+  icoPaddingBottom?: string | number;
+  padding?: string | number;
+  paddingLeft?: string | number;
+  paddingTop?: string | number;
+  paddingRight?: string | number;
+  paddingBottom?: string | number;
   icoTextDecoration?: string;
-  icoLineHeight?: Pixel | Percentage;
+  icoLineHeight?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlNavbarLink.tsx
+++ b/src/mjml/MjmlNavbarLink.tsx
@@ -4,19 +4,13 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-  Ephemeral,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlNavbarLinkProps {
   /** MJML default value: #000000 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontStyle?: string;
   fontWeight?: string;
   href?: string;
@@ -24,14 +18,14 @@ export interface IMjmlNavbarLinkProps {
   /** MJML default value: _blank */
   target?: string;
   rel?: string;
-  letterSpacing?: Pixel | Ephemeral;
-  lineHeight?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  letterSpacing?: string | number;
+  lineHeight?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 15px 10px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];
   className?: string;

--- a/src/mjml/MjmlSection.tsx
+++ b/src/mjml/MjmlSection.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlSectionProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
@@ -29,13 +24,13 @@ export interface IMjmlSectionProps {
   direction?: "ltr" | "rtl";
   fullWidth?: boolean;
   /** MJML default value: 20px 0 */
-  padding?: Matrix<Pixel | Percentage>;
-  paddingTop?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
+  padding?: string | number;
+  paddingTop?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
   textAlign?: React.CSSProperties["textAlign"];
-  textPadding?: Matrix<Pixel | Percentage>;
+  textPadding?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlSocial.tsx
+++ b/src/mjml/MjmlSocial.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlSocialProps {
   /** MJML default value: center */
@@ -19,24 +14,24 @@ export interface IMjmlSocialProps {
   /** MJML default value: #333333 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontStyle?: string;
   fontWeight?: string;
-  iconSize?: Pixel | Percentage;
-  iconHeight?: Pixel | Percentage;
-  iconPadding?: Matrix<Pixel | Percentage>;
-  innerPadding?: Matrix<Pixel | Percentage>;
-  lineHeight?: Pixel | Percentage;
+  iconSize?: string | number;
+  iconHeight?: string | number;
+  iconPadding?: string | number;
+  innerPadding?: string | number;
+  lineHeight?: string | number;
   /** MJML default value: horizontal */
   mode?: "horizontal" | "vertical";
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   tableLayout?: "auto" | "fixed";
-  textPadding?: Matrix<Pixel | Percentage>;
+  textPadding?: string | number;
   textDecoration?: React.CSSProperties["textDecoration"];
   verticalAlign?: React.CSSProperties["verticalAlign"];
   className?: string;

--- a/src/mjml/MjmlSocialElement.tsx
+++ b/src/mjml/MjmlSocialElement.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlSocialElementProps {
   /** MJML default value: left */
@@ -19,22 +14,22 @@ export interface IMjmlSocialElementProps {
   color?: React.CSSProperties["color"];
   borderRadius?: React.CSSProperties["borderRadius"];
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontStyle?: string;
   fontWeight?: string;
   href?: string;
-  iconSize?: Pixel | Percentage;
-  iconHeight?: Pixel | Percentage;
-  iconPadding?: Matrix<Pixel | Percentage>;
-  lineHeight?: Pixel | Percentage;
+  iconSize?: string | number;
+  iconHeight?: string | number;
+  iconPadding?: string | number;
+  lineHeight?: string | number;
   name?: string;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 4px */
-  padding?: Matrix<Pixel | Percentage>;
-  textPadding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
+  textPadding?: string | number;
   rel?: string;
   src?: string;
   srcset?: string;

--- a/src/mjml/MjmlSpacer.tsx
+++ b/src/mjml/MjmlSpacer.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlSpacerProps {
   border?: React.CSSProperties["border"];
@@ -18,13 +13,13 @@ export interface IMjmlSpacerProps {
   borderRight?: string;
   borderTop?: string;
   containerBackgroundColor?: string;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
-  padding?: Matrix<Pixel | Percentage>;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
+  padding?: string | number;
   /** MJML default value: 20px */
-  height?: Pixel | Percentage;
+  height?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlStyle.tsx
+++ b/src/mjml/MjmlStyle.tsx
@@ -16,9 +16,12 @@ export function MjmlStyle({
   children,
   ...props
 }: IMjmlStyleProps): JSX.Element {
-  return React.createElement(
-    "mj-style",
-    convertPropsToMjmlAttributes(props),
-    children
-  );
+  return React.createElement("mj-style", {
+    ...convertPropsToMjmlAttributes(props),
+    dangerouslySetInnerHTML: {
+      __html: props.dangerouslySetInnerHTML
+        ? props.dangerouslySetInnerHTML.__html
+        : children,
+    },
+  });
 }

--- a/src/mjml/MjmlTable.tsx
+++ b/src/mjml/MjmlTable.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlTableProps {
   /** MJML default value: left */
@@ -24,20 +19,20 @@ export interface IMjmlTableProps {
   /** MJML default value: #000000 */
   color?: React.CSSProperties["color"];
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontWeight?: string;
-  lineHeight?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  lineHeight?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   role?: "none" | "presentation";
   tableLayout?: "auto" | "fixed" | "initial" | "inherit";
   verticalAlign?: React.CSSProperties["verticalAlign"];
   /** MJML default value: 100% */
-  width?: Pixel | Percentage;
+  width?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlText.tsx
+++ b/src/mjml/MjmlText.tsx
@@ -4,13 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-  Ephemeral,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlTextProps {
   /** MJML default value: left */
@@ -20,18 +14,18 @@ export interface IMjmlTextProps {
   color?: React.CSSProperties["color"];
   containerBackgroundColor?: string;
   fontFamily?: string;
-  fontSize?: Pixel;
+  fontSize?: string | number;
   fontStyle?: string;
   fontWeight?: string;
-  height?: Pixel | Percentage;
-  letterSpacing?: Pixel | Ephemeral;
-  lineHeight?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
-  paddingTop?: Pixel | Percentage;
+  height?: string | number;
+  letterSpacing?: string | number;
+  lineHeight?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
+  paddingTop?: string | number;
   /** MJML default value: 10px 25px */
-  padding?: Matrix<Pixel | Percentage>;
+  padding?: string | number;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];
   verticalAlign?: React.CSSProperties["verticalAlign"];

--- a/src/mjml/MjmlWrapper.tsx
+++ b/src/mjml/MjmlWrapper.tsx
@@ -4,12 +4,7 @@
  */
 import React from "react";
 
-import {
-  convertPropsToMjmlAttributes,
-  Matrix,
-  Pixel,
-  Percentage,
-} from "../utils";
+import { convertPropsToMjmlAttributes } from "../utils";
 
 export interface IMjmlWrapperProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
@@ -29,13 +24,13 @@ export interface IMjmlWrapperProps {
   direction?: "ltr" | "rtl";
   fullWidth?: boolean;
   /** MJML default value: 20px 0 */
-  padding?: Matrix<Pixel | Percentage>;
-  paddingTop?: Pixel | Percentage;
-  paddingBottom?: Pixel | Percentage;
-  paddingLeft?: Pixel | Percentage;
-  paddingRight?: Pixel | Percentage;
+  padding?: string | number;
+  paddingTop?: string | number;
+  paddingBottom?: string | number;
+  paddingLeft?: string | number;
+  paddingRight?: string | number;
   textAlign?: React.CSSProperties["textAlign"];
-  textPadding?: Matrix<Pixel | Percentage>;
+  textPadding?: string | number;
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/utils/mjml-component-utils.ts
+++ b/src/utils/mjml-component-utils.ts
@@ -2,17 +2,6 @@ import kebabCase from "lodash.kebabcase";
 
 const DANGEROUSLY_SET_INNER_HTML = "dangerouslySetInnerHTML";
 
-export type Matrix<E extends string | number> =
-  | E
-  | `${E} ${E}`
-  | `${E} ${E} ${E}`
-  | `${E} ${E} ${E} ${E}`;
-
-export type Pixel = number | `${number}` | `${number}px`;
-export type Percentage = number | `${number}` | `${number}%`;
-export type Ephemeral = number | `${number}` | `${number}em`;
-export const typeToUnit = { Pixel: "px", Percentage: "%", Ephemeral: "em" };
-
 type MJMLDangerouslySetInnerHTML = {
   __html: string;
 };

--- a/test/__mockData__/mockMjmlReactTestData.tsx
+++ b/test/__mockData__/mockMjmlReactTestData.tsx
@@ -273,7 +273,7 @@ export const mockMjmlReactTestData: MockComponentData = {
     },
     {
       mjmlReact: <MjmlStyle>{"body > div {}"}</MjmlStyle>,
-      expectedMjml: `<mj-style>body &gt; div {}</mj-style>`,
+      expectedMjml: `<mj-style>body > div {}</mj-style>`,
     },
     {
       mjmlReact: (

--- a/test/mjml-props.test.tsx
+++ b/test/mjml-props.test.tsx
@@ -106,20 +106,6 @@ describe("mjml components prop values", () => {
     expect(
       renderToMjml(<MjmlButton padding="0 1px 2% 0px">Button4</MjmlButton>)
     ).toBe('<mj-button padding="0 1px 2% 0px">Button4</mj-button>');
-
-    // Test with invalid props. Code should still render but typescript should
-    // throw an error
-    expect(
-      // @ts-expect-error invalid padding prop (not a matrix) for test purposes
-      renderToMjml(<MjmlButton padding="not a matrix">Button5</MjmlButton>)
-    ).toBe('<mj-button padding="not a matrix">Button5</mj-button>');
-
-    expect(
-      renderToMjml(
-        // @ts-expect-error invalid padding prop (too many values) for test purposes
-        <MjmlButton padding="1px 1px 1px 1px 1px">Button6</MjmlButton>
-      )
-    ).toBe('<mj-button padding="1px 1px 1px 1px 1px">Button6</mj-button>');
   });
 
   it("accepts correct property types for React.CSSProperties", () => {


### PR DESCRIPTION
https://github.com/Faire/mjml-react/pull/38 is a rather big change that makes it difficult to migrate from mjml-react v2 to mjml-react v3. The original goal of v3 was to pick up support of mjml-react and migrate to typescript. Admittedly, we got a bit carried away and added features that make it more difficult than necessary to migrate.

This PR reverts the changes in https://github.com/Faire/mjml-react/pull/38 and makes the mjml-style backwards compatible with v2 of mjml-react. In doing so, we hope that it is easier for users to migrate to v3 of mjml-react. 

We plan to start a v4 alpha branch to still allow users who want these cutting edge features, such as the type safety.