### PR TITLE
add mention of `mjml-dynamic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,13 @@ fixConditionalComment(
 
 ## Limitations
 
-Currently `mjml` and `@faire/mjml-react` libraries are meant to be run inside a node.
+Currently `mjml` and `@faire/mjml-react` libraries are meant to be run inside Node.js.
 
 ## Example project
 
 You can find an example project here
 [https://github.com/wix-incubator/mjml-react-example](https://github.com/wix-incubator/mjml-react-example)
+
+## Related projects
+
+- [`mjml-dynamic`](https://github.com/mifi/mjml-dynamic) - lets you create a `.mjml` template using your favorite tooling, and inject dynamic content. Can be used in conjunction with `mjml-react` to render parts of a `.mjml` using React.


### PR DESCRIPTION
First thanks for taking over the project. I agree that it's too good to go!

One pain point for me using mjml-react is that you cannot easily use one of the [many excellent templates](https://mjml.io/templates) and inject dynamic partial content using react. You would have to rewrite the whole template to React, and in that case you loose all previewing in VSCode and existing tooling. So I created a little library to allow replacing parts of the MJML JSON tree with any content, [including `mjml-react` subtrees](https://github.com/mifi/mjml-dynamic#example-usage-with-mjml-react). So I hope this mention can help other people discover this technique!

also fix a typo