### PR TITLE
Add `number` to `fontWeight` union

### DIFF
--- a/src/mjml/MjmlText.tsx
+++ b/src/mjml/MjmlText.tsx
@@ -16,7 +16,7 @@ export interface IMjmlTextProps {
   fontFamily?: string;
   fontSize?: string | number;
   fontStyle?: string;
-  fontWeight?: string;
+  fontWeight?: string | number;
   height?: string | number;
   letterSpacing?: string | number;
   lineHeight?: string | number;


### PR DESCRIPTION
`fontWeight` can be a `number` (e.g. `700`, `400`).

like

```html
<div style={{ fontWeight: 700 }}>Some text</div>
```