### PR TITLE
fix(components): prefer mjml enum type over CSSProperties

### DIFF
--- a/scripts/generate-mjml-react-utils/getPropTypeFromMjmlAttributeType.ts
+++ b/scripts/generate-mjml-react-utils/getPropTypeFromMjmlAttributeType.ts
@@ -1,0 +1,66 @@
+export const ATTRIBUTES_TO_USE_CSSProperties_WITH = new Set([
+  "color",
+  // "textAlign",
+  // "verticalAlign",
+  "textDecoration",
+  "textTransform",
+
+  "border",
+  "borderRadius",
+  "borderColor",
+  "borderStyle",
+
+  "backgroundColor",
+  "backgroundPosition",
+  // "backgroundRepeat",
+  "backgroundSize",
+]);
+
+/**
+ * Converts an mjml type definition into a typescript type definition
+ * Handles boolean, integer, enum, and
+ * This is used to generate the types on the React <> mjml binding component.
+ */
+export function getPropTypeFromMjmlAttributeType(
+  attribute: string,
+  mjmlAttributeType: string
+): string {
+  if (mjmlAttributeType === "boolean") {
+    return "boolean";
+  }
+  if (mjmlAttributeType === "integer") {
+    return "number";
+  }
+  // e.g. "vertical-align": "enum(top,bottom,middle)"
+  if (mjmlAttributeType.startsWith("enum(")) {
+    return transformEnumType(mjmlAttributeType);
+  }
+  if (ATTRIBUTES_TO_USE_CSSProperties_WITH.has(attribute)) {
+    // When possible prefer using the CSSProperties definitions over the
+    // less helpful "string" or "string | number" type definitions.
+    return `React.CSSProperties["${attribute}"]`;
+  }
+  if (
+    mjmlAttributeType.startsWith("unit") &&
+    mjmlAttributeType.includes("px")
+  ) {
+    return "string | number";
+  }
+  return "string";
+}
+
+/**
+ * Converts an mjml enum type definition into a typescript string literal type.
+ * Strings like `"enum(a,b,c)"` become `"a" | "b" | "c"`.
+ * This is used to generate the types on the React <> mjml binding component.
+ */
+function transformEnumType(mjmlAttributeType: string): string {
+  return (
+    mjmlAttributeType
+      .match(/\(.*\)/)?.[0]
+      ?.slice(1, -1)
+      .split(",")
+      .map((str) => '"' + str + '"')
+      .join(" | ") ?? "unknown"
+  );
+}

--- a/scripts/generate-mjml-react-utils/getPropTypeFromMjmlAttributeType.ts
+++ b/scripts/generate-mjml-react-utils/getPropTypeFromMjmlAttributeType.ts
@@ -1,7 +1,5 @@
 export const ATTRIBUTES_TO_USE_CSSProperties_WITH = new Set([
   "color",
-  // "textAlign",
-  // "verticalAlign",
   "textDecoration",
   "textTransform",
 
@@ -12,7 +10,6 @@ export const ATTRIBUTES_TO_USE_CSSProperties_WITH = new Set([
 
   "backgroundColor",
   "backgroundPosition",
-  // "backgroundRepeat",
   "backgroundSize",
 ]);
 

--- a/src/mjml/MjmlButton.tsx
+++ b/src/mjml/MjmlButton.tsx
@@ -42,8 +42,8 @@ export interface IMjmlButtonProps {
   target?: string;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];
-  verticalAlign?: React.CSSProperties["verticalAlign"];
-  textAlign?: React.CSSProperties["textAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
+  textAlign?: "left" | "right" | "center";
   width?: string | number;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlColumn.tsx
+++ b/src/mjml/MjmlColumn.tsx
@@ -28,7 +28,7 @@ export interface IMjmlColumnProps {
   innerBorderRight?: string;
   innerBorderTop?: string;
   padding?: string | number;
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   width?: string | number;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlGroup.tsx
+++ b/src/mjml/MjmlGroup.tsx
@@ -10,7 +10,7 @@ export interface IMjmlGroupProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   /** MJML default value: ltr */
   direction?: "ltr" | "rtl";
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   width?: string | number;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlHero.tsx
+++ b/src/mjml/MjmlHero.tsx
@@ -30,7 +30,7 @@ export interface IMjmlHeroProps {
   paddingRight?: string | number;
   paddingTop?: string | number;
   backgroundColor?: React.CSSProperties["backgroundColor"];
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlSection.tsx
+++ b/src/mjml/MjmlSection.tsx
@@ -9,7 +9,7 @@ import { convertPropsToMjmlAttributes } from "../utils";
 export interface IMjmlSectionProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   backgroundUrl?: string;
-  backgroundRepeat?: React.CSSProperties["backgroundRepeat"];
+  backgroundRepeat?: "repeat" | "no-repeat";
   backgroundSize?: React.CSSProperties["backgroundSize"];
   backgroundPosition?: React.CSSProperties["backgroundPosition"];
   backgroundPositionX?: string;
@@ -29,7 +29,7 @@ export interface IMjmlSectionProps {
   paddingBottom?: string | number;
   paddingLeft?: string | number;
   paddingRight?: string | number;
-  textAlign?: React.CSSProperties["textAlign"];
+  textAlign?: "left" | "center" | "right";
   textPadding?: string | number;
   className?: string;
   cssClass?: string;

--- a/src/mjml/MjmlSocial.tsx
+++ b/src/mjml/MjmlSocial.tsx
@@ -33,7 +33,7 @@ export interface IMjmlSocialProps {
   tableLayout?: "auto" | "fixed";
   textPadding?: string | number;
   textDecoration?: React.CSSProperties["textDecoration"];
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlSocialElement.tsx
+++ b/src/mjml/MjmlSocialElement.tsx
@@ -39,7 +39,7 @@ export interface IMjmlSocialElementProps {
   /** MJML default value: _blank */
   target?: string;
   textDecoration?: React.CSSProperties["textDecoration"];
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "middle" | "bottom";
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlTable.tsx
+++ b/src/mjml/MjmlTable.tsx
@@ -30,7 +30,7 @@ export interface IMjmlTableProps {
   padding?: string | number;
   role?: "none" | "presentation";
   tableLayout?: "auto" | "fixed" | "initial" | "inherit";
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   /** MJML default value: 100% */
   width?: string | number;
   className?: string;

--- a/src/mjml/MjmlText.tsx
+++ b/src/mjml/MjmlText.tsx
@@ -28,7 +28,7 @@ export interface IMjmlTextProps {
   padding?: string | number;
   textDecoration?: React.CSSProperties["textDecoration"];
   textTransform?: React.CSSProperties["textTransform"];
-  verticalAlign?: React.CSSProperties["verticalAlign"];
+  verticalAlign?: "top" | "bottom" | "middle";
   className?: string;
   cssClass?: string;
   mjmlClass?: string;

--- a/src/mjml/MjmlWrapper.tsx
+++ b/src/mjml/MjmlWrapper.tsx
@@ -9,7 +9,7 @@ import { convertPropsToMjmlAttributes } from "../utils";
 export interface IMjmlWrapperProps {
   backgroundColor?: React.CSSProperties["backgroundColor"];
   backgroundUrl?: string;
-  backgroundRepeat?: React.CSSProperties["backgroundRepeat"];
+  backgroundRepeat?: "repeat" | "no-repeat";
   backgroundSize?: React.CSSProperties["backgroundSize"];
   backgroundPosition?: React.CSSProperties["backgroundPosition"];
   backgroundPositionX?: string;
@@ -29,7 +29,7 @@ export interface IMjmlWrapperProps {
   paddingBottom?: string | number;
   paddingLeft?: string | number;
   paddingRight?: string | number;
-  textAlign?: React.CSSProperties["textAlign"];
+  textAlign?: "left" | "center" | "right";
   textPadding?: string | number;
   className?: string;
   cssClass?: string;

--- a/test/__mockData__/mockMjmlReactTestData.tsx
+++ b/test/__mockData__/mockMjmlReactTestData.tsx
@@ -133,6 +133,11 @@ export const mockMjmlReactTestData: MockComponentData = {
       ),
       expectedMjml: `<mj-section full-width="full-width" padding-top="10px" css-class="first-section">Content</mj-section>`,
     },
+    {
+      // @ts-expect-error invalid textAlign prop for test purposes
+      mjmlReact: <MjmlSection textAlign="start">Content</MjmlSection>,
+      expectedMjml: '<mj-section text-align="start">Content</mj-section>',
+    },
   ],
   MjmlColumn: [
     {

--- a/test/generate-mjml-react/getPropTypeFromMjmlAttributeType.test.ts
+++ b/test/generate-mjml-react/getPropTypeFromMjmlAttributeType.test.ts
@@ -1,0 +1,104 @@
+// import camelCase from "lodash.camelcase";
+import _ from "lodash";
+
+import { IMjmlComponent } from "../../scripts/generate-mjml-react";
+import {
+  ATTRIBUTES_TO_USE_CSSProperties_WITH,
+  getPropTypeFromMjmlAttributeType,
+} from "../../scripts/generate-mjml-react-utils/getPropTypeFromMjmlAttributeType";
+
+describe("getPropTypeFromMjmlAttributeType", () => {
+  test.each`
+    mjmlAttributeType                     | reactType
+    ${"boolean"}                          | ${"boolean"}
+    ${"color"}                            | ${"string"}
+    ${"integer"}                          | ${"number"}
+    ${"string"}                           | ${"string"}
+    ${"unit(px)"}                         | ${"string | number"}
+    ${"unit(px,%)"}                       | ${"string | number"}
+    ${"unit(px,%){1,4}"}                  | ${"string | number"}
+    ${"unit(px,%,)"}                      | ${"string | number"}
+    ${"unit(px,auto)"}                    | ${"string | number"}
+    ${"unitWithNegative(px,em)"}          | ${"string | number"}
+    ${"enum(file-start)"}                 | ${'"file-start"'}
+    ${"enum(auto,fixed)"}                 | ${'"auto" | "fixed"'}
+    ${"enum(auto,fixed,initial,inherit)"} | ${'"auto" | "fixed" | "initial" | "inherit"'}
+    ${"enum(full-width,false,)"}          | ${'"full-width" | "false" | ""'}
+  `(
+    "transforms mjmlType: $mjmlAttributeType into React type: $reactType",
+    ({ mjmlAttributeType, reactType }) => {
+      expect(getPropTypeFromMjmlAttributeType("n/a", mjmlAttributeType)).toBe(
+        reactType
+      );
+    }
+  );
+
+  describe("use CSSProperties for useful mjml types", () => {
+    const presetCoreComponents: Array<IMjmlComponent> =
+      require("mjml-preset-core").components;
+
+    const allMjmlTypesGroupedByAttribute = presetCoreComponents.reduce(
+      (map, component) => {
+        if (component.allowedAttributes !== undefined) {
+          for (const [key, value] of Object.entries(
+            component.allowedAttributes
+          )) {
+            if (map.get(key) === undefined) {
+              map.set(key, new Set());
+            }
+            map.get(key)?.add(value);
+          }
+        }
+        return map;
+      },
+      new Map<string, Set<string>>()
+    );
+
+    const val = _.flatten(
+      Array.from(ATTRIBUTES_TO_USE_CSSProperties_WITH).map((attribute) => {
+        const allMjmlTypes = allMjmlTypesGroupedByAttribute.get(
+          _.kebabCase(attribute)
+        );
+        if (allMjmlTypes === undefined) {
+          // place a debug statement here to view the full allMjmlTypesGroupedByAttribute
+          throw Error(`allMjmlTypes must be defined for ${attribute}`);
+        }
+        return Array.from(allMjmlTypes).map(
+          (mjmlType: string) =>
+            ({
+              mjmlType,
+              attribute,
+            } as { mjmlType: string; attribute: string })
+        );
+      })
+    );
+
+    test.each(val)(
+      "mjml attribute $attribute with type $mjmlType becomes a CSSProperty",
+      ({ mjmlType, attribute }) => {
+        expect(getPropTypeFromMjmlAttributeType(attribute, mjmlType)).toContain(
+          "CSSProperties"
+        );
+      }
+    );
+
+    const cssAttribute = Array.from(ATTRIBUTES_TO_USE_CSSProperties_WITH)[0]!;
+
+    test("CSSProperties preempt 'unit'", () => {
+      expect(
+        getPropTypeFromMjmlAttributeType(cssAttribute, "unit(px)")
+      ).toContain("CSSProperties");
+    });
+    test("CSSProperties does not preempt 'boolean', 'integer', or 'enum'", () => {
+      expect(
+        getPropTypeFromMjmlAttributeType(cssAttribute, "boolean")
+      ).toContain("boolean");
+      expect(
+        getPropTypeFromMjmlAttributeType(cssAttribute, "integer")
+      ).toContain("number");
+      expect(
+        getPropTypeFromMjmlAttributeType(cssAttribute, "enum(x,y,z)")
+      ).toContain('"x"');
+    });
+  });
+});

--- a/test/mjml-props.test.tsx
+++ b/test/mjml-props.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import * as mjmlComponents from "../src";
+import * as mjmlComponents from "../src/mjml";
 import { renderToMjml } from "../src/utils/renderToMjml";
 
 /**


### PR DESCRIPTION
In the previous version enum was being pre-empted by CSSProperties. This resulted in some values not passing type checking when using `validationLevel: "strict"`. Fixes #81