### PR TITLE
chore(deployment): Change the release branch names to `alpha` and `beta`

### DIFF
--- a/.github/workflows/CD_release_npm.yml
+++ b/.github/workflows/CD_release_npm.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
-      - main-beta
-      - main-alpha
+      - main-v2
+      - main-v4
+      - beta
+      - alpha
 
 jobs:
   runCI:

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -35,7 +35,8 @@ In all cases the scope is optional (i.e. the title `feat: add 'graphiteWidth' op
 
 In general, pull requests addressing the latest version should target the [`main`](https://github.com/faire/mjml-react/tree/main) branch.
 
-A current beta or alpha version may exist to test multiple fixes simultaneously, which are reserved under the branch names `main-beta` and `main-alpha`. Eventually this prerelease branch should be merged into `main` without squashing, after which a single version bump from `main` is determined by the most significant type of all merging commits (chore, patch, minor, major).
+A current beta or alpha version may exist to test multiple fixes simultaneously, which are reserved under the branch names `beta` and `alpha`.
+Eventually this prerelease branch should be merged into `main` **_without squashing_**, after which a single version bump from `main` is determined by the most significant type of all merging commits (chore, patch, minor, major).
 
 ## Fixing A Bug
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In V4 we are exploring exciting features that will make mjml-react even more pow
 
 - Improved prop type safety: help ensure correct formatting for props like padding, width, and height
 
-If you want to be on the cutting edge of what is being released, we are publishing a [v4-main-alpha version](https://www.npmjs.com/package/@faire/mjml-react/v/main-alpha) to npm.
+If you want to be on the cutting edge of what is being released, we are publishing a [v4-main-alpha version](https://www.npmjs.com/package/@faire/mjml-react/v/alpha) to npm.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -88,12 +88,18 @@
   "release": {
     "branches": [
       "main",
+      "main-v2",
       {
-        "name": "main-beta",
+        "name": "main-v4",
+        "channel": "alpha",
         "prerelease": true
       },
       {
-        "name": "main-alpha",
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
The tags on npm have `main` in the currently. By using `alpha` and `beta` as the branch names this should remove the "main" from the names