### PR TITLE
fix(import): convert require to esm import

### DIFF
--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -1,9 +1,10 @@
-const entities = require("./html-entities.json");
+import entities from "./html-entities.json";
 
 export function namedEntityToHexCode(html: string): string {
   return html.replace(/&([a-z0-9]{2,8});/gi, (match, p1) => {
-    if (entities[p1]) {
-      return `&#${entities[p1]};`;
+    const anyEntities = entities as any;
+    if (anyEntities[p1]) {
+      return `&#${anyEntities[p1]};`;
     }
     return match;
   });


### PR DESCRIPTION
Related to https://github.com/Faire/mjml-react/issues/96

It seems the require statement was building to require in both esm and cjs. By converting to an esm import it will stay this way in esm and be converted to a require in cjs by the build process. This should fix instances of `ReferenceError: require is not defined`.