### PR TITLE
Fix whitespace removal from minification

### DIFF
--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -32,6 +32,7 @@ export function render(
       html: htmlMinify(parseResults.html, {
         caseSensitive: true,
         collapseWhitespace: true,
+        conservativeCollapse: true,
         minifyCSS: true,
         removeComments: true,
         removeEmptyAttributes: true,


### PR DESCRIPTION
Minification is turning 
```<mj-text>Label:</mj-text><mj-text> Value<br></mj-text>```
into
```<mj-text>Label:</mj-text><mj-text>Value<br></mj-text>```