### PR TITLE
fix(CI): Bump node versions tested

### DIFF
--- a/.github/workflows/CI_PR_merge_checks.yml
+++ b/.github/workflows/CI_PR_merge_checks.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Version 14 and 16 of node are no longer in their maintenance window.
The two currently maintained lts versions of node are 18 and 20.
ref: https://nodejs.org/en/about/previous-releases
