### PR TITLE
fix(CI): Bump node version of release action

### DIFF
--- a/.github/workflows/CD_release_npm.yml
+++ b/.github/workflows/CD_release_npm.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Configure Github credentials


### PR DESCRIPTION
https://github.com/Faire/mjml-react/pull/116 failed to publish because the release action is still on node version 16. Bump to version 20.