### PR TITLE
feat(utils/render): Accept mjml or mjml-browser in render() utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,14 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "mjml": "^4.13.0",
+    "mjml-core": "^4.15.3",
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "mjml-core": {
+      "optional": true
+    }
   },
   "module": "dist/esm/index.js",
   "dependencies": {

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,6 +1,6 @@
 import { minify as htmlMinify } from "html-minifier";
-import mjml2html from "mjml";
 import { MJMLParsingOptions, MJMLJsonObject, MJMLParseError } from "mjml-core";
+import type mjml2htmlType from "mjml-core";
 import React from "react";
 
 import { renderToMjml } from "./renderToMjml";
@@ -12,6 +12,7 @@ interface ConvertedHtml {
 }
 
 export function render(
+  mjml2html: typeof mjml2htmlType,
   email: React.ReactElement,
   options: MJMLParsingOptions = {}
 ): ConvertedHtml {

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -1,3 +1,4 @@
+import mjml2html from "mjml";
 import React from "react";
 
 import { Mjml, MjmlHead, MjmlTitle, MjmlBody, MjmlRaw } from "../src";
@@ -17,7 +18,7 @@ describe("render()", () => {
         </MjmlBody>
       </Mjml>
     );
-    const { html } = render(email, { minify: true });
+    const { html } = render(mjml2html, email, { minify: true });
     expect(html).toBeDefined();
     expect(html).toContain("<!doctype html>");
     expect(html).toContain("<title>Title</title>");
@@ -32,7 +33,7 @@ describe("render()", () => {
         </MjmlBody>
       </Mjml>
     );
-    expect(() => render(email)).toThrow(
+    expect(() => render(mjml2html, email)).toThrow(
       "Element div doesn't exist or is not registered"
     );
   });
@@ -45,7 +46,7 @@ describe("render()", () => {
         </MjmlBody>
       </Mjml>
     );
-    const { errors } = render(email, {
+    const { errors } = render(mjml2html, email, {
       validationLevel: "soft",
       minify: false,
     });


### PR DESCRIPTION
BREAKING CHANGE: `utils/render` now requires an additional argument, the import of either `mjml` or `mjml-browser`.

If you are not using the render utility, this has no effect. However, the mjml peer dependency has been removed, and so can be removed if not using for any other purpose. mjml-core has been added as an optional peer dependency for typings. 

This change both allows greater flexibility, and removes dependencies pulled in via `mjml` -> `mjml-cli` unless necessary (using this utility).

Before:

```js
render(email, options)
```

After:

```js
import mjml2html from "mjml";
render(mjml2html, email, options);
```

Note: the render utility is undocumented.

