### PR TITLE
chore(release): update release action

### DIFF
--- a/.github/workflows/CD_release_npm.yml
+++ b/.github/workflows/CD_release_npm.yml
@@ -10,19 +10,29 @@ on:
 jobs:
   runCI:
     uses: ./.github/workflows/CI_PR_merge_checks.yml
+
   releaseAndBumpVersion:
     needs: runCI
     name: Publish the package
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm i -g npm@^11.5.1
 
       - name: Configure Github credentials
         run: |
@@ -39,5 +49,4 @@ jobs:
           npx semantic-release
         env:
           HUSKY: 0
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
NPM no longer supports classic tokens. Update to use github as trusted publisher